### PR TITLE
[백준 2775]<수학, 구현, dp>: 부녀회장이 될테야

### DIFF
--- a/Baekjoon/2775.py
+++ b/Baekjoon/2775.py
@@ -1,0 +1,33 @@
+'''
+문제 링크:https://www.acmicpc.net/problem/2775
+카테고리: 수학, 구현, 다이나믹 프로그래밍
+문제해설: 부녀회장이 될테야
+<조건>
+a층b호에 살려면 a-1층의 1호부터 b호까지 
+사람들의 수의  합만큼 데려와 살아야함
+빈 집없음
+
+입력 K층, n호에 몇명이 살고있는지 출력
+0층부터, 1호부터 있고 0층의 i호에는 i명 거주
+
+0층9호->9
+1층3호->1+2+3=6
+2층3호->1층1호+1층2호+1층3호=1+(1+2)+(1+2+3)
+dp 이용-> 이전 i번째 항까지 합이 다음 항
+'''
+#bottom-up
+test_case=int(input())
+
+for _ in range(test_case):
+  k=int(input())
+  n=int(input())
+
+  resident=[[i for i in range(1,n+1)]]
+
+  for i in range(1,k+1):
+    temp=[]
+    for j in range(1,n+1):
+      temp.append(sum(resident[i-1][:j]))
+    resident.append(temp)
+
+  print(resident[-1][-1])


### PR DESCRIPTION
```bash
개요: 관련 이슈, 문제 링크, 문제 요약 등을 작성합니다.
카테고리: 알고리즘 문제 사이트에서 제공하는 카테고리를 작성합니다.
문제해설: 구체적인 문제해설을 작성합니다.
```

### 개요
문제 링크:https://www.acmicpc.net/problem/2775
### 카테고리
수학, 구현, 다이나믹 프로그래밍
### 문제 해설
<조건>
a층b호에 살려면 a-1층의 1호부터 b호까지 
사람들의 수의  합만큼 데려와 살아야함
빈 집없음

입력 K층, n호에 몇명이 살고있는지 출력
0층부터, 1호부터 있고 0층의 i호에는 i명 거주

0층9호->9
1층3호->1+2+3=6
2층3호->1층1호+1층2호+1층3호=1+(1+2)+(1+2+3)
dp 이용-> 이전 i번째 항까지 합이 다음 항

bottom-up : 반복문사용
1. 2차원 배열로 0층 만들어 놓기
2. 이중 반복문으로 k층 n호의 값 붙여주기