### PR TITLE
[백준: 13705]<수학, 이분탐색, 임의 정밀도 / 큰 수 연산, 수치해석>: Ax+Bsin(x)=C

### DIFF
--- a/Baekjoon/cakejin/13705.py
+++ b/Baekjoon/cakejin/13705.py
@@ -25,35 +25,47 @@ f'(x)=A+Bcos(x)
 
 import sys
 import math
+from decimal import Decimal, getcontext
+
+getcontext().prec = 50
 
 A, B, C = map(int, input().split())
 
+
 #초기값 설정
-a = C - 1
-b = C + 1
-c = (a + b)/2
-er = 0.0000000001
+a = Decimal(C - 1)
+b = Decimal(C + 1)
+c = Decimal((a + b)/2) 
+er = Decimal("1e-9")
 
 def f(x):
-    sin_x = math.sin(x)
-    return A*x + B*sin_x - C
+    sin_x = str(math.sin(float(x)))
+    return A*x + B*Decimal(sin_x) - C
+
 
 while f(a)*f(b) > 0:
-    a -= 1
-    b += 1
+    a -= 1 #Decimal(a-1)
+    b += 1 #Decimal(b+1)
 
-while b - c > er:
+while b - a > er:
     fb = f(b)
     fc = f(c)
 
     if fb*fc <= 0: #fb가 양수, fc가 음수 -> a=c, b=b
         a = c
-        c = (a + b)/2
+       
     else: #fb,fc둘다 양수->a=a, b=c
         b = c
-        c = (a + b)/2
+    c = (a + b)/2
 
-print(round(c, 6))
+print(f"{c:.6f}")
+        
+
+
+
+
+
+
         
 
 

--- a/Baekjoon/cakejin/13705.py
+++ b/Baekjoon/cakejin/13705.py
@@ -9,16 +9,14 @@ A, B, C가 주어졌을 때, Ax+Bsin(x)=C를 만족하는 x를 찾는 프로그�
 출력: 소수점 여섯째 자리까지 출력(반올림)
 
 f(x)=Ax+Bsin(x)-C=0의 수치해 찾기
-f'(x)=A+Bcos(x)
 
 해가 존재하는 구간 모름: a1,b1사이에 존재한다 가정
                         (f(a1)f(b1) < 0 인 a1,b1찾기)
-                        f(x): 증가함수 -> Ax+Bsin(x) 의 해는 0근방
-                            f(x)의 해는 C근방
+                        f(x): 증가함수
 
-1.이분법 이용
+이분법 이용
     a1,b1사이에 근 존재-> cn=(an+bn)/2
-    bn-cn <= 오차 -> break, cn이 수치해
+    bn-an <= 오차 -> break, cn이 수치해
     안끝나면: f(an)f(cn)<=0 ->an+1 = an, bn+1 = cn
                        >=0 ->an+1 = cn, bn+1 = b 
 소수의 정확한 연산
@@ -28,7 +26,7 @@ f'(x)=A+Bcos(x)
 import sys
 import decimal
 
-# Decimal의 정밀도를 50자리까지 설정
+# Decimal의 정밀도를 100자리까지 설정
 decimal.getcontext().prec = 100
 decimal.getcontext().rounding = decimal.ROUND_HALF_UP
 

--- a/Baekjoon/cakejin/13705.py
+++ b/Baekjoon/cakejin/13705.py
@@ -27,27 +27,51 @@ import sys
 import math
 from decimal import Decimal, getcontext
 
+# Decimal의 정밀도를 50자리까지 설정
 getcontext().prec = 50
 
-A, B, C = map(int, input().split())
-
+A, B, C = map(int, sys.stdin.readline().split())
+A, B, C = Decimal(A), Decimal(B), Decimal(C)
 
 #초기값 설정
-a = Decimal(C - 1)
-b = Decimal(C + 1)
-c = Decimal((a + b)/2) 
-er = Decimal("1e-9")
+#a = Decimal(-1)
+#b = Decimal(1)
+a = C / A - Decimal("1")
+b = C / A + Decimal("1")
+
+tol = Decimal("1e-7")
+
+#def factorial1(n):
+#    fac = 1
+#    for i in range(2, n + 1):
+#        fac *= i
+#    return fac
+
+def sin_meclaurin(x, terms = 20):
+    x = Decimal(x)
+    result = Decimal(0)
+    term = x
+    for n in range(1, terms + 1):
+        result += term
+        #term *= ((-1) ** n) * (x ** (2 * n +1)) / factorial1(2 * n  + 1)
+        term *= -x**2 / (2 * n * (2 * n + 1))
+        if abs(term) < tol:
+            break
+    return result
+
+
 
 def f(x):
-    sin_x = str(math.sin(float(x)))
-    return A*x + B*Decimal(sin_x) - C
+    #sin_x = math.sin(x)
+    return A * x + B * sin_meclaurin(x) - C
 
 
 while f(a)*f(b) > 0:
-    a -= 1 #Decimal(a-1)
-    b += 1 #Decimal(b+1)
+    a -= Decimal("1")
+    b += Decimal("1")
 
-while b - a > er:
+while abs(b - a) > tol:
+    c = ((a + b)/2) 
     fb = f(b)
     fc = f(c)
 
@@ -56,13 +80,8 @@ while b - a > er:
        
     else: #fb,fc둘다 양수->a=a, b=c
         b = c
-    c = (a + b)/2
 
 print(f"{c:.6f}")
-        
-
-
-
 
 
 

--- a/Baekjoon/cakejin/13705.py
+++ b/Baekjoon/cakejin/13705.py
@@ -1,0 +1,62 @@
+'''
+작성자: cakejin
+문제 링크: https://www.acmicpc.net/problem/13705
+카테고리: 수학, 이분탐색, 임의 정밀도 / 큰 수 연산, 수치해석
+문제 해설: Ax+Bsin(x)=C
+
+A, B, C가 주어졌을 때, Ax+Bsin(x)=C를 만족하는 x를 찾는 프로그램을 작성
+입력: 첫째 줄 정수 A, B, C
+출력: 소수점 여섯째 자리까지 출력(반올림)
+
+f(x)=Ax+Bsin(x)-C=0의 수치해 찾기
+f'(x)=A+Bcos(x)
+
+해가 존재하는 구간 모름: a1,b1사이에 존재한다 가정
+                        (f(a1)f(b1) < 0 인 a1,b1찾기)
+                        f(x): 증가함수 -> Ax+Bsin(x) 의 해는 0근방
+                            f(x)의 해는 C근방
+
+1.이분법 이용
+    a1,b1사이에 근 존재-> cn=(an+bn)/2
+    bn-cn <= 오차 -> break, cn이 수치해
+    안끝나면: f(an)f(cn)<=0 ->an+1 = an, bn+1 = cn
+                       >=0 ->an+1 = cn, bn+1 = b 
+'''
+
+import sys
+import math
+
+A, B, C = map(int, input().split())
+
+#초기값 설정
+a = C - 1
+b = C + 1
+c = (a + b)/2
+er = 0.0000000001
+
+def f(x):
+    sin_x = math.sin(x)
+    return A*x + B*sin_x - C
+
+while f(a)*f(b) > 0:
+    a -= 1
+    b += 1
+
+while b - c > er:
+    fb = f(b)
+    fc = f(c)
+
+    if fb*fc <= 0: #fb가 양수, fc가 음수 -> a=c, b=b
+        a = c
+        c = (a + b)/2
+    else: #fb,fc둘다 양수->a=a, b=c
+        b = c
+        c = (a + b)/2
+
+print(round(c, 6))
+        
+
+
+
+
+

--- a/Baekjoon/cakejin/13705.py
+++ b/Baekjoon/cakejin/13705.py
@@ -21,40 +21,38 @@ f'(x)=A+Bcos(x)
     bn-cn <= 오차 -> break, cn이 수치해
     안끝나면: f(an)f(cn)<=0 ->an+1 = an, bn+1 = cn
                        >=0 ->an+1 = cn, bn+1 = b 
+소수의 정확한 연산
+-부동 소수점 말고 고정 소수점 이용: Decimal
 '''
 
 import sys
-import math
-from decimal import Decimal, getcontext
+import decimal
 
 # Decimal의 정밀도를 50자리까지 설정
-getcontext().prec = 50
+decimal.getcontext().prec = 100
+decimal.getcontext().rounding = decimal.ROUND_HALF_UP
 
 A, B, C = map(int, sys.stdin.readline().split())
-A, B, C = Decimal(A), Decimal(B), Decimal(C)
+A, B, C = decimal.Decimal(A), decimal.Decimal(B), decimal.Decimal(C)
 
 #초기값 설정
-#a = Decimal(-1)
-#b = Decimal(1)
-a = C / A - Decimal("1")
-b = C / A + Decimal("1")
+#-1<sin<1
+a = decimal.Decimal("0")
+b = decimal.Decimal("10")
 
-tol = Decimal("1e-7")
+tol = decimal.Decimal("1e-20")
 
-#def factorial1(n):
-#    fac = 1
-#    for i in range(2, n + 1):
-#        fac *= i
-#    return fac
-
-def sin_meclaurin(x, terms = 20):
-    x = Decimal(x)
-    result = Decimal(0)
+def sin_meclaurin(x, terms = 25):
+    result = decimal.Decimal(0)
+    #x범위를 -2pi~2pi로 축소
+    pi = decimal.Decimal('3.141592653589793238462643383279502884197169399375105820974944592307816406286')
+    two_pi = decimal.Decimal('2') * pi
+    x = x % two_pi
     term = x
     for n in range(1, terms + 1):
         result += term
-        #term *= ((-1) ** n) * (x ** (2 * n +1)) / factorial1(2 * n  + 1)
-        term *= -x**2 / (2 * n * (2 * n + 1))
+        #term *= ((-1) ** n) * (x ** (2 * n +1)) / factorial(2 * n  + 1)
+        term *= decimal.Decimal(-x ** 2) / (decimal.Decimal(2 * n) * decimal.Decimal(2 * n + 1))
         if abs(term) < tol:
             break
     return result
@@ -62,26 +60,27 @@ def sin_meclaurin(x, terms = 20):
 
 
 def f(x):
-    #sin_x = math.sin(x)
     return A * x + B * sin_meclaurin(x) - C
 
 
 while f(a)*f(b) > 0:
-    a -= Decimal("1")
-    b += Decimal("1")
+    a -= decimal.Decimal("1")
+    b += decimal.Decimal("1")
 
 while abs(b - a) > tol:
-    c = ((a + b)/2) 
-    fb = f(b)
+    c = (a + b)/2 
+    fa = f(a)
     fc = f(c)
 
-    if fb*fc <= 0: #fb가 양수, fc가 음수 -> a=c, b=b
+    if abs(fc) <= tol:
+        break
+    elif fa * fc > 0:
         a = c
-       
-    else: #fb,fc둘다 양수->a=a, b=c
+ 
+    else: 
         b = c
 
-print(f"{c:.6f}")
+print(round(c, 6))
 
 
 


### PR DESCRIPTION
```bash
개요: 관련 이슈, 문제 링크, 문제 요약 등을 작성합니다.
카테고리: 알고리즘 문제 사이트에서 제공하는 카테고리를 작성합니다.
문제해설: 구체적인 문제해설을 작성합니다.
```

### 개요
 https://www.acmicpc.net/problem/13705
### 카테고리
수학, 이분탐색, 임의 정밀도 / 큰 수 연산, 수치해석
### 문제 해설
Ax+Bsin(x)=C

A, B, C가 주어졌을 때, Ax+Bsin(x)=C를 만족하는 x를 찾는 프로그램을 작성
입력: 첫째 줄 정수 A, B, C
출력: 소수점 여섯째 자리까지 출력(반올림)

f(x)=Ax+Bsin(x)-C=0의 수치해 찾기

해가 존재하는 구간 모름: a1,b1사이에 존재한다 가정
                        (f(a1)f(b1) < 0 인 a1,b1찾기)
                  
이분법 이용
    a1,b1사이에 근 존재-> cn=(an+bn)/2
    bn-an <= 오차 -> break, cn이 수치해
    안끝나면: f(an)f(cn)<=0 ->an+1 = an, bn+1 = cn
                       >=0 ->an+1 = cn, bn+1 = b 

소수의 정확한 연산이 필요한 문제 같습니다. 
또한 시간 초과가 나올 수 있으므로 초깃값 설정도 적절한 값으로 고려해야하는거 같습니다.

매클로린 급수로 사인 함수를 나타낼 땐 단순 함수 구현 뿐이 아닌 x값의 범위도 정해줘야 정확한 계산이 가능했습니다.