### PR TITLE
[백준 1644]<소수 판정, 투 포인터>: 소수의 연속합

### DIFF
--- a/Baekjoon/99mini/1644.py
+++ b/Baekjoon/99mini/1644.py
@@ -9,15 +9,24 @@
 - 에라토스테네스의 체
 
 문제 해설
+1. `find_prime_suffix`: 에라토스테네스의 체를 이용하여 소수 판별 후 소수의 누적합 반환
+2. 투 포인터로 start(=0)와 end(=1)를 사용.
+    - 누적합(start ~ end)의 값이 목표값(n)과 같으면 결과값 +1
+    - 누적합의 값이 목표값보다 작으면 end값 +1
+    - 그렇지 않은 경우 start값 +1
+    - start와 end값이 소수의 누적합 배열의 길이보다 작을 때까지 반복 
 '''
 
 import math
 
 n = int(input())
 
-def find_prime(n):
+def find_prime_suffix(n):
+    if n < 2:
+        return []
+
     prime_nums = [True] * (n + 1)
-    ret = []
+    ret = [2]
 
     for i in range(2, math.ceil(math.sqrt(n + 1))):
         if prime_nums[i]:
@@ -26,24 +35,22 @@ def find_prime(n):
 
     for i in range(2, n + 1):
         if prime_nums[i]:
-            ret.append(i)
+            ret.append(ret[-1] + i)
 
     return ret
 
-prime_nums = find_prime(n)
-
-print(prime_nums)
+prime_num_suffix = find_prime_suffix(n)
 
 ret = 0
+
+len_of_prime_num_suffix = len(prime_num_suffix)
+
 start = 0
 end = 1
 
-while start < n and end < n:
-    sum_of_prime = sum(prime_nums[start:end + 1])
+while start < len_of_prime_num_suffix and end < len_of_prime_num_suffix:
+    sum_of_prime = prime_num_suffix[end] - prime_num_suffix[start]
     if sum_of_prime == n:
-        print(start , '~', end)
-        print(*prime_nums[start:end + 1], sep=' ')
-        print(sum_of_prime)
         ret = ret + 1
         start = start + 1
     elif sum_of_prime < n:
@@ -51,6 +58,4 @@ while start < n and end < n:
     else:
         start = start + 1
 
-print()
-print('result: ', end='')
 print(ret)

--- a/Baekjoon/99mini/1644.py
+++ b/Baekjoon/99mini/1644.py
@@ -1,0 +1,56 @@
+'''
+작성자: 99mini
+문제 링크: https://www.acmicpc.net/problem/1644
+카테고리
+- 수학
+- 정수론
+- 두 포인터
+- 소수 판정
+- 에라토스테네스의 체
+
+문제 해설
+'''
+
+import math
+
+n = int(input())
+
+def find_prime(n):
+    prime_nums = [True] * (n + 1)
+    ret = []
+
+    for i in range(2, math.ceil(math.sqrt(n + 1))):
+        if prime_nums[i]:
+            for j in range(i * 2, n + 1, i):
+                prime_nums[j] = False
+
+    for i in range(2, n + 1):
+        if prime_nums[i]:
+            ret.append(i)
+
+    return ret
+
+prime_nums = find_prime(n)
+
+print(prime_nums)
+
+ret = 0
+start = 0
+end = 1
+
+while start < n and end < n:
+    sum_of_prime = sum(prime_nums[start:end + 1])
+    if sum_of_prime == n:
+        print(start , '~', end)
+        print(*prime_nums[start:end + 1], sep=' ')
+        print(sum_of_prime)
+        ret = ret + 1
+        start = start + 1
+    elif sum_of_prime < n:
+        end = end + 1
+    else:
+        start = start + 1
+
+print()
+print('result: ', end='')
+print(ret)


### PR DESCRIPTION
```bash
개요: 관련 이슈, 문제 링크, 문제 요약 등을 작성합니다.
카테고리: 알고리즘 문제 사이트에서 제공하는 카테고리를 작성합니다.
문제해설: 구체적인 문제해설을 작성합니다.
```

### 개요

문제 링크: https://www.acmicpc.net/problem/1644

### 카테고리

- 수학
- 정수론
- 두 포인터
- 소수 판정
- 에라토스테네스의 체

### 문제 해설

```
입력받은 정수(n)이 연속된 소수의 합으로 나타낼 수 있는 경우의 수를 구하여라

예시]
input 41
output 3
note 
2+3+5+7+11+13 = 11+13+17 = 41
```

1. `find_prime_suffix`: 에라토스테네스의 체를 이용하여 소수 판별 후 소수의 누적합 반환
2. 투 포인터로 start(=0)와 end(=1)를 사용.
    - 누적합(start ~ end)의 값이 목표값(n)과 같으면 결과값 +1
    - 누적합의 값이 목표값보다 작으면 end값 +1
    - 그렇지 않은 경우 start값 +1
    - start와 end값이 소수의 누적합 배열의 길이보다 작을 때까지 반복 

> 시간 초과가 될만한 요소가 `소수 판별`, `누적합`, `투포인터` 3가지라서 고려할 점이 많았다.
