### PR TITLE
[백준]<분리 집합>: 유니온-파인드 문제 풀이 7511, 1976, 20040

### DIFF
--- a/Baekjoon/99mini/1976.py
+++ b/Baekjoon/99mini/1976.py
@@ -1,0 +1,50 @@
+'''
+작성자: 99mini
+문제 링크: https://www.acmicpc.net/problem/1976
+카테고리: 자료 구조, 그래프 이론, 그래프 탐색, 분리 집합
+문제 해설
+- 유니온-파인드 문제
+- 인접 행렬 방식
+'''
+
+import sys
+
+input = sys.stdin.readline
+
+def find(disjoint_set, x) -> int:
+    '''
+    부모 찾기
+    '''
+    if x != disjoint_set[x]:
+        return find(disjoint_set, disjoint_set[x])
+    return x
+
+def union(disjoint_set, a, b) -> list[int]:
+    '''
+    분리 집합 병합
+    '''
+
+    a, b = find(disjoint_set, a), find(disjoint_set, b) 
+
+    if a < b:
+        disjoint_set[b] = a
+    elif a > b:
+        disjoint_set[a] = b
+    
+    return disjoint_set
+
+n = int(input())
+m = int(input())
+
+cities = list(i for i in range(n))
+
+for i in range(n):
+    row = list(map(int, input().split()))
+
+    for j, is_connected in enumerate(row):
+        if is_connected:
+            cities = union(cities, i, j)
+
+dist = list(map(lambda x: find(cities, int(x) - 1), input().split()))
+
+print ('YES' if len(set(dist)) == 1 else 'NO')

--- a/Baekjoon/99mini/20040.py
+++ b/Baekjoon/99mini/20040.py
@@ -1,0 +1,63 @@
+'''
+작성자: 99mini
+문제 링크: https://www.acmicpc.net/problem/20040
+카테고리: 자료 구조, 분리 집합
+문제 해설
+- 유니온-파인드 문제
+- a와 b가 부모가 같은 경우: find(disjoint_set, a) == find(disjoint_set, b)
+
+개선 사항
+
+```python3
+# main()
+if find(game, a) == find(game, b):
+    return i + 1
+        
+game = union(game, a, b)
+```
+find함수 호출과 union 함수 호출에서 동일한 find 함수를 2번씩 중복호출하고 있음.
+'''
+
+import sys
+
+input = sys.stdin.readline
+
+def find(disjoint_set, x) -> int:
+    '''
+    부모 찾기
+    '''
+    if x != disjoint_set[x]:
+        return find(disjoint_set, disjoint_set[x])
+    return x
+
+def union(disjoint_set, a, b) -> list[int]:
+    '''
+    분리 집합 병합
+    '''
+
+    a, b = find(disjoint_set, a), find(disjoint_set, b) 
+
+    if a < b:
+        disjoint_set[b] = a
+    elif a > b:
+        disjoint_set[a] = b
+    
+    return disjoint_set
+
+
+def main():
+    n, m = map(int, input().split())
+
+    game = list(i for i in range(n))
+
+    for i in range(m):
+        a, b = map(int, input().split())
+
+        if find(game, a) == find(game, b):
+            return i + 1
+        
+        game = union(game, a, b)
+
+    return 0
+
+print(main())

--- a/Baekjoon/99mini/7511.py
+++ b/Baekjoon/99mini/7511.py
@@ -1,0 +1,54 @@
+'''
+작성자: 99mini
+문제 링크: https://www.acmicpc.net/problem/7511
+카테고리: 자료 구조, 그래프 이론, 분리 집합
+문제 해설
+'''
+
+def generate_disjoint_set(graph, n):
+    '''
+    분리 집합 생성
+    '''
+    return list(i for i in range(n))
+
+
+def is_same_parent(disjoint_set, a, b):
+    '''
+    같은 집합의 노드인지 판별
+    '''
+
+    return disjoint_set[a] == disjoint_set[b]
+
+t = int(input())
+
+for test_number in range(t):
+
+    print(f"Scenario {test_number + 1}:")
+
+    n = int(input())
+    k = int(input())
+
+    graph: dict[int, list[int]] = {}
+
+    for i in range(n):
+        graph[i] = []
+
+    for _ in range(k):
+        a, b = map(int, input().split())
+
+        graph[a].append(b)
+        graph[b].append(a)
+
+    disjoint_set = generate_disjoint_set(graph, n)
+
+    m = int(input())
+
+    for _ in range(m):
+        a, b = map(int, input().split())
+
+        print(1 if is_same_parent(disjoint_set, a, b) else 0)
+    
+    if test_number + 1 < n:
+        print()
+
+

--- a/Baekjoon/99mini/7511.py
+++ b/Baekjoon/99mini/7511.py
@@ -6,6 +6,10 @@
 유니온-파인드 문제
 '''
 
+import sys
+
+input = sys.stdin.readline
+
 def find(disjoint_set, x):
     '''
     부모 찾기

--- a/Baekjoon/99mini/7511.py
+++ b/Baekjoon/99mini/7511.py
@@ -3,21 +3,30 @@
 문제 링크: https://www.acmicpc.net/problem/7511
 카테고리: 자료 구조, 그래프 이론, 분리 집합
 문제 해설
+유니온-파인드 문제
 '''
 
-def generate_disjoint_set(graph, n):
+def find(disjoint_set, x):
     '''
-    분리 집합 생성
+    부모 찾기
     '''
-    return list(i for i in range(n))
+    if x != disjoint_set[x]:
+        return find(disjoint_set, disjoint_set[x])
+    return x
 
-
-def is_same_parent(disjoint_set, a, b):
+def union(disjoint_set, a, b):
     '''
-    같은 집합의 노드인지 판별
+    분리 집합 병합
     '''
 
-    return disjoint_set[a] == disjoint_set[b]
+    a, b = find(disjoint_set, a), find(disjoint_set, b) 
+
+    if a < b:
+        disjoint_set[b] = a
+    elif a > b:
+        disjoint_set[a] = b
+    
+    return disjoint_set
 
 t = int(input())
 
@@ -28,27 +37,18 @@ for test_number in range(t):
     n = int(input())
     k = int(input())
 
-    graph: dict[int, list[int]] = {}
-
-    for i in range(n):
-        graph[i] = []
+    disjoint_set = list(i for i in range(n))
 
     for _ in range(k):
         a, b = map(int, input().split())
 
-        graph[a].append(b)
-        graph[b].append(a)
-
-    disjoint_set = generate_disjoint_set(graph, n)
-
+        union(disjoint_set, a, b)
+        
     m = int(input())
 
     for _ in range(m):
         a, b = map(int, input().split())
-
-        print(1 if is_same_parent(disjoint_set, a, b) else 0)
+        print(1 if find(disjoint_set, a) == find(disjoint_set, b) else 0)
     
     if test_number + 1 < n:
         print()
-
-


### PR DESCRIPTION
```bash
개요: 관련 이슈, 문제 링크, 문제 요약 등을 작성합니다.
카테고리: 알고리즘 문제 사이트에서 제공하는 카테고리를 작성합니다.
문제해설: 구체적인 문제해설을 작성합니다.
```

### 개요

문제이름: 소셜 네트워킹 어플리케이션
문제 링크: https://www.acmicpc.net/problem/7511

### 카테고리

- 자료 구조
- 그래프 이론
- 분리 집합

### 문제 해설

단순 유니온-파인드 문제

---

### 개요

문제이름: 여행 가자
문제 링크: https://www.acmicpc.net/problem/1976

### 카테고리

- 자료 구조
- 그래프 이론
- 그래프 탐색
- 분리 집합

### 문제 해설

- 단순 유니온-파인드 문제
- 인접 행렬 방식 입력

```python3
# Baekjoon/99mini/1976.py L48:50
dist = list(map(lambda x: find(cities, int(x) - 1), input().split()))

print ('YES' if len(set(dist)) == 1 else 'NO')
```

개선점: 모든 목적지 도시의 부모를 찾고, set을 이용하여 부모가 다른 경우가 있는 지 검증 -> 성능 향상을 위하여 부모를 하나씩 찾으며 달라진 경우가 생기면 일찍 끝낼 수도 있을 것 같다.

---

### 개요

문제이름: 사이클 게임
문제 링크: https://www.acmicpc.net/problem/20040

### 카테고리

- 자료 구조
- 분리 집합

### 문제 해설

- 유니온-파인드 문제
- a와 b가 부모가 같은 경우: find(disjoint_set, a) == find(disjoint_set, b)

개선 사항

```python3
# Baekjoon/99mini/20040.py L56:59
if find(game, a) == find(game, b):
    return i + 1
        
game = union(game, a, b)
```

find함수 호출과 union 함수 호출에서 동일한 find 함수를 2번씩 중복호출하고 있음.
